### PR TITLE
Add interface and endpoint_override parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,43 @@ variable.
         checkEveryMinutes: 1
         regions: ["region1"]
 
+Regions with the ``openstack`` type can be configured without checking Keystone
+certificate with the ``insecure: false`` value, it also means that ``cacert``
+is optional and can be omitted.
+
+By default, the Neutron endpoint with the ``public`` interface is used for
+security analyses. The type of endpoint can be changed by the ``interface``
+parameter with three available values ``public``, ``private`` and ``admin``:
+
+.. code-block::
+
+    regions:
+      - type: openstack
+        name: region1
+        insecure: false
+        interface: admin
+        credentials:
+          auth_url: http://example.net:5000/
+          username: admin
+          password: admin
+          tenant_name: admin
+
+By some reasons, it is valuable not to use ServiceCatalog to determine
+the Neutron endpoint but specify it with some certain value. For this case
+the ``endpoint_override`` should be used:
+
+.. code-block::
+
+    regions:
+      - type: openstack
+        name: region1
+        insecure: false
+        endpoint_override: http://example.net:9696/
+        credentials:
+          auth_url: http://example.net:5000/
+          username: admin
+          password: admin
+          tenant_name: admin
 
 SSL configuration for CCP
 *************************
@@ -70,8 +107,6 @@ In case your region requires ssl, CCP config should have additional fields
 
       files:
         region1-key.pem: /opt/key.pem
-
-where section under files has mappings: *<region_name>-key.pem: <key_path>
 
 Service configuration example
 *****************************

--- a/etc/security-checker.yaml
+++ b/etc/security-checker.yaml
@@ -16,6 +16,16 @@ regions:
       username: admin
       password: admin
       tenant_name: admin
+    interface: admin
+
+  - type: openstack
+    name: re3
+    credentials:
+      auth_url: http://example.com:5000/v2.0/
+      username: admin
+      password: admin
+      tenant_name: admin
+    endpoint_override: http://example.com:9696/
 
 elastic:
   hosts:

--- a/security/config.py
+++ b/security/config.py
@@ -64,7 +64,15 @@ SCHEMA = {
                     "additionalProperties": False,
                 },
                 "cacert": {"type": "string"},
-                "insecure": {"type": "boolean"}
+                "insecure": {"type": "boolean"},
+                "interface": {
+                    "type": "string",
+                    "oneOf": [
+                        {"enum": ["public", "internal", "admin"]},
+                        {"enum": ["publicURL", "internalURL", "adminURL"]},
+                    ],
+                },
+                "endpoint_override": {"format": "uri"},
             },
             "required": ["type", "name", "credentials"],
             "additionalProperties": False,

--- a/security/plugins/secgroup.py
+++ b/security/plugins/secgroup.py
@@ -60,7 +60,11 @@ class Plugin(base.Plugin):
             if cacert:
                 sess_kwargs["verify"] = cacert
         sess = session.Session(**sess_kwargs)
-        neutron = client.Client(session=sess)
+        neutron = client.Client(
+            interface=region.get("interface", "public"),
+            endpoint_override=region.get("endpoint_override"),
+            session=sess,
+        )
         for sg in neutron.list_security_groups()["security_groups"]:
             LOG.debug("Checking security group %s", sg["name"])
             for rule in sg["security_group_rules"]:


### PR DESCRIPTION
The interface parameter is needed to choose an endpoint by its type for
the Neutron service from ServiceCatalog.

The endpoint_override parameters is needed to force using of the given
endpoint instead of endpoinds which are provided by ServiceCatalog.